### PR TITLE
Test against Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 
 rvm:
   - "2.0.0"
-  - "2.3.1"
+  - "2.5.0"
 
 notifications:
   email: false


### PR DESCRIPTION
This PR adds Ruby 2.5.0 to travis test matrix.